### PR TITLE
fix(sms.users.callback): add missing annotation

### DIFF
--- a/packages/ovh-manager-sms/users/callback/telecom-sms-users-callback.controller.js
+++ b/packages/ovh-manager-sms/users/callback/telecom-sms-users-callback.controller.js
@@ -3,6 +3,8 @@ import _ from 'lodash';
 
 export default class TelecomSmsUsersCallbackCtrl {
   constructor($q, $stateParams, $timeout, $uibModalInstance, OvhApiSms, user) {
+    'ngInject';
+
     this.$q = $q;
     this.$stateParams = $stateParams;
     this.$timeout = $timeout;


### PR DESCRIPTION
Prevents error:
```js
Error: "[$injector:strictdi] TelecomSmsUsersCallbackCtrl is not using explicit annotation and cannot be invoked in strict mode
https://errors.angularjs.org/1.6.10/$injector/strictdi?p0=TelecomSmsUsersCallbackCtrl"
```