### PR TITLE
wip(sms.options): add manage/recredit/response module

### DIFF
--- a/packages/ovh-manager-sms/options/manage/telecom-sms-options-manage.controller.js
+++ b/packages/ovh-manager-sms/options/manage/telecom-sms-options-manage.controller.js
@@ -1,5 +1,10 @@
-angular.module('managerApp').controller('TelecomSmsOptionsManageCtrl', class TelecomSmsOptionsManageCtrl {
+import smsOptionsManageUpdateTemplate from './update/telecom-sms-options-manage-update.html';
+import smsOptionsManageUpdateController from './update/telecom-sms-options-manage-update.controller';
+
+export default class TelecomSmsOptionsManageCtrl {
   constructor($uibModal, SmsMediator, ToastError) {
+    'ngInject';
+
     this.$uibModal = $uibModal;
     this.SmsMediator = SmsMediator;
     this.ToastError = ToastError;
@@ -22,16 +27,16 @@ angular.module('managerApp').controller('TelecomSmsOptionsManageCtrl', class Tel
   }
 
   /**
-     * Opens a modal to manage sms' options.
-     * @param  {Object} service SmsService.
-     */
+   * Opens a modal to manage sms' options.
+   * @param  {Object} service SmsService.
+   */
   update(service) {
     this.$uibModal.open({
       animation: true,
-      templateUrl: 'app/telecom/sms/options/manage/update/telecom-sms-options-manage-update.html',
-      controller: 'TelecomSmsOptionsManageUpdateCtrl',
+      template: smsOptionsManageUpdateTemplate,
+      controller: smsOptionsManageUpdateController,
       controllerAs: 'OptionsManageUpdateCtrl',
       resolve: { service: () => service },
     });
   }
-});
+}

--- a/packages/ovh-manager-sms/options/manage/telecom-sms-options-manage.js
+++ b/packages/ovh-manager-sms/options/manage/telecom-sms-options-manage.js
@@ -1,16 +1,17 @@
-angular.module('managerApp').config(($stateProvider) => {
-  $stateProvider.state('telecom.sms.options.manage', {
-    url: '/manage',
-    views: {
-      'smsView@telecom.sms': {
-        templateUrl: 'app/telecom/sms/options/manage/telecom-sms-options-manage.html',
-        controller: 'TelecomSmsOptionsManageCtrl',
-        controllerAs: 'TelecomSmsOptionsManageCtrl',
-      },
-    },
-    translations: [
-      'common',
-      'telecom/sms/options/manage',
-    ],
-  });
-});
+import angular from 'angular';
+import uiRouter from '@uirouter/angularjs';
+import uiBootstrap from 'angular-ui-bootstrap';
+import resource from 'angular-resource';
+import translate from 'angular-translate';
+
+import routes from './telecom-sms-options-manage.routes';
+
+export default angular
+  .module('ovhManagerOptionsManage', [
+    uiRouter,
+    uiBootstrap,
+    resource,
+    translate,
+  ])
+  .config(routes)
+  .name;

--- a/packages/ovh-manager-sms/options/manage/telecom-sms-options-manage.routes.js
+++ b/packages/ovh-manager-sms/options/manage/telecom-sms-options-manage.routes.js
@@ -1,0 +1,18 @@
+import controller from './telecom-sms-options-manage.controller';
+import template from './telecom-sms-options-manage.html';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('sms.options.manage', {
+    url: '/manage',
+    views: {
+      'smsView@sms': {
+        template,
+        controller,
+        controllerAs: 'TelecomSmsOptionsManageCtrl',
+      },
+    },
+    resolve: {
+      translations: /* @ngInject */ ($translate, asyncLoader) => import(`./translations/Messages_${$translate.use()}.xml`).then(module => asyncLoader.addTranslations(module.default).then(() => $translate.refresh()).then(() => true)),
+    },
+  });
+};

--- a/packages/ovh-manager-sms/options/manage/update/telecom-sms-options-manage-update.controller.js
+++ b/packages/ovh-manager-sms/options/manage/update/telecom-sms-options-manage-update.controller.js
@@ -1,5 +1,10 @@
-angular.module('managerApp').controller('TelecomSmsOptionsManageUpdateCtrl', class TelecomSmsOptionsManageUpdateCtrl {
+import angular from 'angular';
+import _ from 'lodash';
+
+export default class TelecomSmsOptionsManageUpdateCtrl {
   constructor($q, $stateParams, $timeout, $uibModalInstance, OvhApiSms, service) {
+    'ngInject';
+
     this.$q = $q;
     this.$stateParams = $stateParams;
     this.$timeout = $timeout;
@@ -23,9 +28,9 @@ angular.module('managerApp').controller('TelecomSmsOptionsManageUpdateCtrl', cla
   }
 
   /**
-     * Set callBack and stopCallBack URL.
-     * @return {Promise}
-     */
+   * Set callBack and stopCallBack URL.
+   * @return {Promise}
+   */
   setUrls() {
     this.loading.updateOptions = true;
     return this.$q.all([
@@ -54,13 +59,13 @@ angular.module('managerApp').controller('TelecomSmsOptionsManageUpdateCtrl', cla
   }
 
   /**
-     * Has changed helper.
-     * @return {Boolean}
-     */
+   * Has changed helper.
+   * @return {Boolean}
+   */
   hasChanged() {
     return !_.isEqual(
       _.pick(this.model.service, this.attributs),
       _.pick(this.service, this.attributs),
     );
   }
-});
+}

--- a/packages/ovh-manager-sms/options/recredit/telecom-sms-options-recredit.controller.js
+++ b/packages/ovh-manager-sms/options/recredit/telecom-sms-options-recredit.controller.js
@@ -1,77 +1,82 @@
-angular
-  .module('managerApp')
-  .controller('TelecomSmsOptionsRecreditCtrl', class TelecomSmsOptionsRecreditCtrl {
-    constructor(
-      $q, $stateParams, $translate, $uibModal,
-      OvhApiOrderSms, SmsMediator, Toast, ToastError,
-    ) {
-      this.$q = $q;
-      this.$stateParams = $stateParams;
-      this.$translate = $translate;
-      this.$uibModal = $uibModal;
-      this.api = {
-        orderSms: OvhApiOrderSms.v6(),
-      };
-      this.SmsMediator = SmsMediator;
-      this.Toast = Toast;
-      this.ToastError = ToastError;
+import _ from 'lodash';
+
+import smsOptionsRecreditUpdateTemplate from './update/telecom-sms-options-recredit-update.html';
+import smsOptionsRecreditUpdateController from './update/telecom-sms-options-recredit-update.controller';
+
+export default class TelecomSmsOptionsRecreditCtrl {
+  constructor(
+    $q, $stateParams, $translate, $uibModal,
+    OvhApiOrderSms, SmsMediator, Toast, ToastError,
+  ) {
+    'ngInject';
+
+    this.$q = $q;
+    this.$stateParams = $stateParams;
+    this.$translate = $translate;
+    this.$uibModal = $uibModal;
+    this.api = {
+      orderSms: OvhApiOrderSms.v6(),
+    };
+    this.SmsMediator = SmsMediator;
+    this.Toast = Toast;
+    this.ToastError = ToastError;
+  }
+
+  $onInit() {
+    this.loading = {
+      init: false,
+      price: false,
+    };
+    this.service = null;
+
+    this.loading.init = true;
+    return this.SmsMediator.initDeferred.promise.then(() => {
+      this.service = this.SmsMediator.getCurrentSmsService();
+      return this.service;
+    }).then(service => this.fetchOfferPrice(service)).catch((err) => {
+      this.ToastError(err);
+    }).finally(() => {
+      this.loading.init = false;
+    });
+  }
+
+  /**
+   * Fetch offer price.
+   * @param  {Ojbect} service SmsService
+   * @return {Promise}
+   */
+  fetchOfferPrice(service) {
+    if (service.automaticRecreditAmount !== null) {
+      return this.api.orderSms.getCredits({
+        serviceName: this.$stateParams.serviceName,
+        quantity: service.automaticRecreditAmount,
+      }).$promise.then(credits => _.result(credits, 'prices.withoutTax')).then(price => _.assign(service, { price }));
     }
+    _.set(service, 'price', null);
+    return this.$q.when(service);
+  }
 
-    $onInit() {
-      this.loading = {
-        init: false,
-        price: false,
-      };
-      this.service = null;
-
-      this.loading.init = true;
-      return this.SmsMediator.initDeferred.promise.then(() => {
-        this.service = this.SmsMediator.getCurrentSmsService();
-        return this.service;
-      }).then(service => this.fetchOfferPrice(service)).catch((err) => {
-        this.ToastError(err);
-      }).finally(() => {
-        this.loading.init = false;
+  /**
+   * Opens a modal to manage sms recredit options.
+   * @param  {Object} service SmsService
+   */
+  update(service) {
+    const modal = this.$uibModal.open({
+      animation: true,
+      template: smsOptionsRecreditUpdateTemplate,
+      controller: smsOptionsRecreditUpdateController,
+      controllerAs: 'OptionsRecreditUpdateCtrl',
+      resolve: { service: () => service },
+    });
+    modal.result.then(() => {
+      this.loading.price = true;
+      return this.fetchOfferPrice(this.service).finally(() => {
+        this.loading.price = false;
       });
-    }
-
-    /**
-     * Fetch offer price.
-     * @param  {Ojbect} service SmsService
-     * @return {Promise}
-     */
-    fetchOfferPrice(service) {
-      if (service.automaticRecreditAmount !== null) {
-        return this.api.orderSms.getCredits({
-          serviceName: this.$stateParams.serviceName,
-          quantity: service.automaticRecreditAmount,
-        }).$promise.then(credits => _.result(credits, 'prices.withoutTax')).then(price => _.assign(service, { price }));
+    }).catch((error) => {
+      if (error && error.type === 'API') {
+        this.Toast.error(this.$translate.instant('sms_options_recredit_update_ko', { error: error.message }));
       }
-      _.set(service, 'price', null);
-      return this.$q.when(service);
-    }
-
-    /**
-     * Opens a modal to manage sms recredit options.
-     * @param  {Object} service SmsService
-     */
-    update(service) {
-      const modal = this.$uibModal.open({
-        animation: true,
-        templateUrl: 'app/telecom/sms/options/recredit/update/telecom-sms-options-recredit-update.html',
-        controller: 'TelecomSmsOptionsRecreditUpdateCtrl',
-        controllerAs: 'OptionsRecreditUpdateCtrl',
-        resolve: { service: () => service },
-      });
-      modal.result.then(() => {
-        this.loading.price = true;
-        return this.fetchOfferPrice(this.service).finally(() => {
-          this.loading.price = false;
-        });
-      }).catch((error) => {
-        if (error && error.type === 'API') {
-          this.Toast.error(this.$translate.instant('sms_options_recredit_update_ko', { error: error.message }));
-        }
-      });
-    }
-  });
+    });
+  }
+}

--- a/packages/ovh-manager-sms/options/recredit/telecom-sms-options-recredit.js
+++ b/packages/ovh-manager-sms/options/recredit/telecom-sms-options-recredit.js
@@ -1,16 +1,17 @@
-angular.module('managerApp').config(($stateProvider) => {
-  $stateProvider.state('telecom.sms.options.recredit', {
-    url: '/recredit',
-    views: {
-      'smsView@telecom.sms': {
-        templateUrl: 'app/telecom/sms/options/recredit/telecom-sms-options-recredit.html',
-        controller: 'TelecomSmsOptionsRecreditCtrl',
-        controllerAs: 'TelecomSmsOptionsRecreditCtrl',
-      },
-    },
-    translations: [
-      'common',
-      'telecom/sms/options/recredit',
-    ],
-  });
-});
+import angular from 'angular';
+import uiRouter from '@uirouter/angularjs';
+import uiBootstrap from 'angular-ui-bootstrap';
+import resource from 'angular-resource';
+import translate from 'angular-translate';
+
+import routes from './telecom-sms-options-recredit.routes';
+
+export default angular
+  .module('ovhManagerOptionsRecredit', [
+    uiRouter,
+    uiBootstrap,
+    resource,
+    translate,
+  ])
+  .config(routes)
+  .name;

--- a/packages/ovh-manager-sms/options/recredit/telecom-sms-options-recredit.routes.js
+++ b/packages/ovh-manager-sms/options/recredit/telecom-sms-options-recredit.routes.js
@@ -1,0 +1,18 @@
+import controller from './telecom-sms-options-recredit.controller';
+import template from './telecom-sms-options-recredit.html';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('sms.options.recredit', {
+    url: '/recredit',
+    views: {
+      'smsView@sms': {
+        template,
+        controller,
+        controllerAs: 'TelecomSmsOptionsRecreditCtrl',
+      },
+    },
+    resolve: {
+      translations: /* @ngInject */ ($translate, asyncLoader) => import(`./translations/Messages_${$translate.use()}.xml`).then(module => asyncLoader.addTranslations(module.default).then(() => $translate.refresh()).then(() => true)),
+    },
+  });
+};

--- a/packages/ovh-manager-sms/options/recredit/update/telecom-sms-options-recredit-update.controller.js
+++ b/packages/ovh-manager-sms/options/recredit/update/telecom-sms-options-recredit-update.controller.js
@@ -1,107 +1,110 @@
-angular
-  .module('managerApp')
-  .controller('TelecomSmsOptionsRecreditUpdateCtrl', class TelecomSmsOptionsRecreditUpdateCtrl {
-    constructor(
-      $q, $stateParams, $timeout, $uibModalInstance,
-      OvhApiOrderSms, OvhApiSms, SmsMediator, service, ToastError,
-    ) {
-      this.$q = $q;
-      this.$stateParams = $stateParams;
-      this.$timeout = $timeout;
-      this.$uibModalInstance = $uibModalInstance;
-      this.api = {
-        sms: OvhApiSms.v6(),
-        orderSms: OvhApiOrderSms.v6(),
-      };
-      this.SmsMediator = SmsMediator;
-      this.service = service;
-      this.ToastError = ToastError;
-    }
+import angular from 'angular';
+import _ from 'lodash';
 
-    $onInit() {
-      this.loading = {
-        init: false,
-        updateOptions: false,
-        price: false,
-      };
-      this.updated = false;
-      this.model = {
-        service: angular.copy(this.service),
-      };
-      this.availablePackQuantity = [];
-      this.price = null;
-      this.attributs = ['creditThresholdForAutomaticRecredit', 'automaticRecreditAmount'];
+export default class TelecomSmsOptionsRecreditUpdateCtrl {
+  constructor(
+    $q, $stateParams, $timeout, $uibModalInstance,
+    OvhApiOrderSms, OvhApiSms, SmsMediator, service, ToastError,
+  ) {
+    'ngInject';
 
-      this.loading.init = true;
-      return this.SmsMediator.initDeferred.promise
-        .then(() => this.SmsMediator.getApiScheme().then((schema) => {
-          this.availablePackQuantity = _.sortBy(_.map(schema.models['sms.PackQuantityAutomaticRecreditEnum'].enum, Number));
-        })).then(this.getAmount()).catch((err) => {
-          this.ToastError(err);
-        }).finally(() => {
-          this.loading.init = false;
-        });
-    }
+    this.$q = $q;
+    this.$stateParams = $stateParams;
+    this.$timeout = $timeout;
+    this.$uibModalInstance = $uibModalInstance;
+    this.api = {
+      sms: OvhApiSms.v6(),
+      orderSms: OvhApiOrderSms.v6(),
+    };
+    this.SmsMediator = SmsMediator;
+    this.service = service;
+    this.ToastError = ToastError;
+  }
 
-    /**
-     * Get amount without tax.
-     * @return {Promise}
-     */
-    getAmount() {
-      if (this.model.service.automaticRecreditAmount) {
-        this.loading.price = true;
-        return this.api.orderSms.getCredits({
-          serviceName: this.$stateParams.serviceName,
-          quantity: this.model.service.automaticRecreditAmount,
-        }).$promise.then((credits) => {
-          this.price = _.result(credits, 'prices.withoutTax');
-          return this.price;
-        }).finally(() => {
-          this.loading.price = false;
-        });
-      }
-      this.price = null;
-      return this.$q.when(null);
-    }
+  $onInit() {
+    this.loading = {
+      init: false,
+      updateOptions: false,
+      price: false,
+    };
+    this.updated = false;
+    this.model = {
+      service: angular.copy(this.service),
+    };
+    this.availablePackQuantity = [];
+    this.price = null;
+    this.attributs = ['creditThresholdForAutomaticRecredit', 'automaticRecreditAmount'];
 
-    /**
-     * Set automatic recredit option.
-     * @return {Promise}
-     */
-    setAutomaticRecredit() {
-      this.loading.updateOptions = true;
-      return this.$q.all([
-        this.api.sms.put({
-          serviceName: this.$stateParams.serviceName,
-        }, _.pick(this.model.service, this.attributs)).$promise,
-        this.$timeout(angular.noop, 1000),
-      ]).then(() => {
-        this.loading.updateOptions = false;
-        this.updated = true;
-        _.assign(this.service, _.pick(this.model.service, this.attributs), { price: null });
-        return this.$timeout(() => this.close(), 1500);
-      }).catch(error => this.cancel({
-        type: 'API',
-        msg: error,
-      }));
-    }
+    this.loading.init = true;
+    return this.SmsMediator.initDeferred.promise
+      .then(() => this.SmsMediator.getApiScheme().then((schema) => {
+        this.availablePackQuantity = _.sortBy(_.map(schema.models['sms.PackQuantityAutomaticRecreditEnum'].enum, Number));
+      })).then(this.getAmount()).catch((err) => {
+        this.ToastError(err);
+      }).finally(() => {
+        this.loading.init = false;
+      });
+  }
 
-    cancel(message) {
-      return this.$uibModalInstance.dismiss(message);
+  /**
+   * Get amount without tax.
+   * @return {Promise}
+   */
+  getAmount() {
+    if (this.model.service.automaticRecreditAmount) {
+      this.loading.price = true;
+      return this.api.orderSms.getCredits({
+        serviceName: this.$stateParams.serviceName,
+        quantity: this.model.service.automaticRecreditAmount,
+      }).$promise.then((credits) => {
+        this.price = _.result(credits, 'prices.withoutTax');
+        return this.price;
+      }).finally(() => {
+        this.loading.price = false;
+      });
     }
+    this.price = null;
+    return this.$q.when(null);
+  }
 
-    close() {
-      return this.$uibModalInstance.close(true);
-    }
+  /**
+   * Set automatic recredit option.
+   * @return {Promise}
+   */
+  setAutomaticRecredit() {
+    this.loading.updateOptions = true;
+    return this.$q.all([
+      this.api.sms.put({
+        serviceName: this.$stateParams.serviceName,
+      }, _.pick(this.model.service, this.attributs)).$promise,
+      this.$timeout(angular.noop, 1000),
+    ]).then(() => {
+      this.loading.updateOptions = false;
+      this.updated = true;
+      _.assign(this.service, _.pick(this.model.service, this.attributs), { price: null });
+      return this.$timeout(() => this.close(), 1500);
+    }).catch(error => this.cancel({
+      type: 'API',
+      msg: error,
+    }));
+  }
 
-    /**
-     * Has changed helper.
-     * @return {Boolean}
-     */
-    hasChanged() {
-      return !_.isEqual(
-        _.pick(this.model.service, this.attributs),
-        _.pick(this.service, this.attributs),
-      );
-    }
-  });
+  cancel(message) {
+    return this.$uibModalInstance.dismiss(message);
+  }
+
+  close() {
+    return this.$uibModalInstance.close(true);
+  }
+
+  /**
+   * Has changed helper.
+   * @return {Boolean}
+   */
+  hasChanged() {
+    return !_.isEqual(
+      _.pick(this.model.service, this.attributs),
+      _.pick(this.service, this.attributs),
+    );
+  }
+}

--- a/packages/ovh-manager-sms/options/response/add/telecom-sms-options-response-add.controller.js
+++ b/packages/ovh-manager-sms/options/response/add/telecom-sms-options-response-add.controller.js
@@ -1,105 +1,108 @@
-angular
-  .module('managerApp')
-  .controller('TelecomSmsOptionsResponseAddCtrl', class TelecomSmsOptionsResponseAddCtrl {
-    constructor(
-      $q, $stateParams, $timeout, $uibModalInstance,
-      params, OvhApiSms, SmsMediator, ToastError,
-    ) {
-      this.$q = $q;
-      this.$stateParams = $stateParams;
-      this.$timeout = $timeout;
-      this.$uibModalInstance = $uibModalInstance;
-      this.api = {
-        sms: OvhApiSms.v6(),
-      };
-      this.service = params.service;
-      this.senders = params.senders;
-      this.SmsMediator = SmsMediator;
-      this.ToastError = ToastError;
-    }
+import angular from 'angular';
+import _ from 'lodash';
 
-    $onInit() {
-      this.loading = {
-        init: false,
-        addTrackingOption: false,
-      };
-      this.added = false;
-      this.model = {
-        service: angular.copy(this.service),
-        senders: angular.copy(this.senders),
-      };
-      this.availableTrackingMedia = [];
-      this.trackingOptions = {};
-      this.targetNumberPattern = /^(\+|0{2}?)\d+$/;
+export default class TelecomSmsOptionsResponseAddCtrl {
+  constructor(
+    $q, $stateParams, $timeout, $uibModalInstance,
+    params, OvhApiSms, SmsMediator, ToastError,
+  ) {
+    'ngInject';
 
-      this.loading.init = true;
-      return this.SmsMediator.initDeferred.promise
-        .then(() => this.SmsMediator.getApiScheme().then((schema) => {
-          this.availableTrackingMedia = _.pull(schema.models['sms.ResponseTrackingMediaEnum'].enum, 'voice');
-          return this.availableTrackingMedia;
-        })).catch((err) => {
-          this.ToastError(err);
-        }).finally(() => {
-          this.loading.init = false;
-        });
-    }
+    this.$q = $q;
+    this.$stateParams = $stateParams;
+    this.$timeout = $timeout;
+    this.$uibModalInstance = $uibModalInstance;
+    this.api = {
+      sms: OvhApiSms.v6(),
+    };
+    this.service = params.service;
+    this.senders = params.senders;
+    this.SmsMediator = SmsMediator;
+    this.ToastError = ToastError;
+  }
 
-    /**
-     * Reset tracking options.
-     */
-    resetTrackingOptions() {
-      this.trackingOptions.sender = '';
-      this.trackingOptions.target = '';
-    }
+  $onInit() {
+    this.loading = {
+      init: false,
+      addTrackingOption: false,
+    };
+    this.added = false;
+    this.model = {
+      service: angular.copy(this.service),
+      senders: angular.copy(this.senders),
+    };
+    this.availableTrackingMedia = [];
+    this.trackingOptions = {};
+    this.targetNumberPattern = /^(\+|0{2}?)\d+$/;
 
-    /**
-     * Handle tracking sender number.
-     */
-    handleTrackingSenderNumber() {
-      this.trackingOptions.sender = _.has(this.trackingSender, 'sender') ? this.trackingSender.sender : '';
-    }
+    this.loading.init = true;
+    return this.SmsMediator.initDeferred.promise
+      .then(() => this.SmsMediator.getApiScheme().then((schema) => {
+        this.availableTrackingMedia = _.pull(schema.models['sms.ResponseTrackingMediaEnum'].enum, 'voice');
+        return this.availableTrackingMedia;
+      })).catch((err) => {
+        this.ToastError(err);
+      }).finally(() => {
+        this.loading.init = false;
+      });
+  }
 
-    /**
-     * Restrict target number.
-     */
-    restrictTargetNumber() {
-      if (this.trackingOptions.target) {
-        this.trackingOptions.target = this.trackingOptions.target.replace(/[^0-9+]/g, '');
-      }
-    }
+  /**
+   * Reset tracking options.
+   */
+  resetTrackingOptions() {
+    this.trackingOptions.sender = '';
+    this.trackingOptions.target = '';
+  }
 
-    /**
-     * Add sms response tracking options.
-     * @return {Promise}
-     */
-    add() {
-      this.loading.addTrackingOption = true;
-      this.model.service.smsResponse.trackingOptions.push(this.trackingOptions);
-      return this.$q.all([
-        this.api.sms.edit({
-          serviceName: this.$stateParams.serviceName,
-        }, {
-          smsResponse: {
-            trackingOptions: this.model.service.smsResponse.trackingOptions,
-            responseType: this.model.service.smsResponse.responseType,
-          },
-        }).$promise,
-        this.$timeout(angular.noop, 1000),
-      ]).then(() => {
-        this.loading.addTrackingOption = false;
-        this.added = true;
-        return this.$timeout(() => this.close(), 1000);
-      }).catch(error => this.cancel({
-        type: 'API',
-        message: error.data.message,
-      }));
-    }
+  /**
+   * Handle tracking sender number.
+   */
+  handleTrackingSenderNumber() {
+    this.trackingOptions.sender = _.has(this.trackingSender, 'sender') ? this.trackingSender.sender : '';
+  }
 
-    cancel(message) {
-      return this.$uibModalInstance.dismiss(message);
+  /**
+   * Restrict target number.
+   */
+  restrictTargetNumber() {
+    if (this.trackingOptions.target) {
+      this.trackingOptions.target = this.trackingOptions.target.replace(/[^0-9+]/g, '');
     }
+  }
 
-    close() {
-      return this.$uibModalInstance.close(true);
-    }
-  });
+  /**
+   * Add sms response tracking options.
+   * @return {Promise}
+   */
+  add() {
+    this.loading.addTrackingOption = true;
+    this.model.service.smsResponse.trackingOptions.push(this.trackingOptions);
+    return this.$q.all([
+      this.api.sms.edit({
+        serviceName: this.$stateParams.serviceName,
+      }, {
+        smsResponse: {
+          trackingOptions: this.model.service.smsResponse.trackingOptions,
+          responseType: this.model.service.smsResponse.responseType,
+        },
+      }).$promise,
+      this.$timeout(angular.noop, 1000),
+    ]).then(() => {
+      this.loading.addTrackingOption = false;
+      this.added = true;
+      return this.$timeout(() => this.close(), 1000);
+    }).catch(error => this.cancel({
+      type: 'API',
+      message: error.data.message,
+    }));
+  }
+
+  cancel(message) {
+    return this.$uibModalInstance.dismiss(message);
+  }
+
+  close() {
+    return this.$uibModalInstance.close(true);
+  }
+}

--- a/packages/ovh-manager-sms/options/response/edit/telecom-sms-options-response-edit.controller.js
+++ b/packages/ovh-manager-sms/options/response/edit/telecom-sms-options-response-edit.controller.js
@@ -1,99 +1,102 @@
-angular
-  .module('managerApp')
-  .controller('TelecomSmsOptionsResponseEditCtrl', class TelecomSmsOptionsResponseEditCtrl {
-    constructor(
-      $q, $stateParams, $timeout, $uibModalInstance,
-      OvhApiSms, SmsMediator, service, senders, index, option, ToastError,
-    ) {
-      this.$q = $q;
-      this.$stateParams = $stateParams;
-      this.$timeout = $timeout;
-      this.$uibModalInstance = $uibModalInstance;
-      this.api = {
-        sms: OvhApiSms.v6(),
-      };
-      this.SmsMediator = SmsMediator;
-      this.service = service;
-      this.senders = senders;
-      this.index = index;
-      this.option = option;
-      this.ToastError = ToastError;
-    }
+import angular from 'angular';
+import _ from 'lodash';
 
-    $onInit() {
-      this.loading = {
-        init: false,
-        editTrackingOption: false,
-      };
-      this.edited = false;
-      this.model = {
-        service: angular.copy(this.service),
-        senders: angular.copy(this.senders),
-        index: this.index,
-        option: angular.copy(this.option),
-      };
-      this.availableTrackingMedia = [];
-      this.trackingOptions = {};
-      this.trackingSender = {};
-      this.targetNumberPattern = /^\+?[\d+]{8,14}$/;
+export default class TelecomSmsOptionsResponseEditCtrl {
+  constructor(
+    $q, $stateParams, $timeout, $uibModalInstance,
+    OvhApiSms, SmsMediator, service, senders, index, option, ToastError,
+  ) {
+    'ngInject';
 
-      this.loading.init = true;
-      return this.SmsMediator.initDeferred.promise
-        .then(() => this.SmsMediator.getApiScheme().then((schema) => {
-          this.availableTrackingMedia = _.pull(schema.models['sms.ResponseTrackingMediaEnum'].enum, 'voice');
-          this.trackingOptions.media = this.model.option.media;
-          this.trackingSender.sender = this.model.option.sender;
-        })).catch((err) => {
-          this.ToastError(err);
-        }).finally(() => {
-          this.loading.init = false;
-        });
-    }
+    this.$q = $q;
+    this.$stateParams = $stateParams;
+    this.$timeout = $timeout;
+    this.$uibModalInstance = $uibModalInstance;
+    this.api = {
+      sms: OvhApiSms.v6(),
+    };
+    this.SmsMediator = SmsMediator;
+    this.service = service;
+    this.senders = senders;
+    this.index = index;
+    this.option = option;
+    this.ToastError = ToastError;
+  }
 
-    /**
-     * Edit sms tesponse tracking options.
-     * @return {Promise}
-     */
-    edit() {
-      this.model.service.smsResponse.trackingOptions[this.model.index] = {
-        media: this.trackingOptions.media,
-        sender: this.trackingOptions.media === 'sms' ? _.get(this.trackingSender.sender, 'sender') : this.model.option.sender,
-        target: this.model.option.target,
-      };
-      this.loading.editTrackingOption = true;
-      return this.$q.all([
-        this.api.sms.edit({
-          serviceName: this.$stateParams.serviceName,
-        }, {
-          smsResponse: {
-            trackingOptions: this.model.service.smsResponse.trackingOptions,
-            responseType: this.model.service.smsResponse.responseType,
-          },
-        }).$promise,
-        this.$timeout(angular.noop, 1000),
-      ]).then(() => {
-        this.loading.editTrackingOption = false;
-        this.edited = true;
-        return this.$timeout(() => this.close(), 1000);
-      }).catch(error => this.cancel({
-        type: 'API',
-        msg: error,
-      }));
-    }
+  $onInit() {
+    this.loading = {
+      init: false,
+      editTrackingOption: false,
+    };
+    this.edited = false;
+    this.model = {
+      service: angular.copy(this.service),
+      senders: angular.copy(this.senders),
+      index: this.index,
+      option: angular.copy(this.option),
+    };
+    this.availableTrackingMedia = [];
+    this.trackingOptions = {};
+    this.trackingSender = {};
+    this.targetNumberPattern = /^\+?[\d+]{8,14}$/;
 
-    /**
-     * Reset tracking options.
-     */
-    resetTrackingOptions() {
-      this.model.option.sender = '';
-      this.model.option.target = '';
-    }
+    this.loading.init = true;
+    return this.SmsMediator.initDeferred.promise
+      .then(() => this.SmsMediator.getApiScheme().then((schema) => {
+        this.availableTrackingMedia = _.pull(schema.models['sms.ResponseTrackingMediaEnum'].enum, 'voice');
+        this.trackingOptions.media = this.model.option.media;
+        this.trackingSender.sender = this.model.option.sender;
+      })).catch((err) => {
+        this.ToastError(err);
+      }).finally(() => {
+        this.loading.init = false;
+      });
+  }
 
-    cancel(message) {
-      return this.$uibModalInstance.dismiss(message);
-    }
+  /**
+   * Edit sms tesponse tracking options.
+   * @return {Promise}
+   */
+  edit() {
+    this.model.service.smsResponse.trackingOptions[this.model.index] = {
+      media: this.trackingOptions.media,
+      sender: this.trackingOptions.media === 'sms' ? _.get(this.trackingSender.sender, 'sender') : this.model.option.sender,
+      target: this.model.option.target,
+    };
+    this.loading.editTrackingOption = true;
+    return this.$q.all([
+      this.api.sms.edit({
+        serviceName: this.$stateParams.serviceName,
+      }, {
+        smsResponse: {
+          trackingOptions: this.model.service.smsResponse.trackingOptions,
+          responseType: this.model.service.smsResponse.responseType,
+        },
+      }).$promise,
+      this.$timeout(angular.noop, 1000),
+    ]).then(() => {
+      this.loading.editTrackingOption = false;
+      this.edited = true;
+      return this.$timeout(() => this.close(), 1000);
+    }).catch(error => this.cancel({
+      type: 'API',
+      msg: error,
+    }));
+  }
 
-    close() {
-      return this.$uibModalInstance.close(true);
-    }
-  });
+  /**
+   * Reset tracking options.
+   */
+  resetTrackingOptions() {
+    this.model.option.sender = '';
+    this.model.option.target = '';
+  }
+
+  cancel(message) {
+    return this.$uibModalInstance.dismiss(message);
+  }
+
+  close() {
+    return this.$uibModalInstance.close(true);
+  }
+}

--- a/packages/ovh-manager-sms/options/response/remove/telecom-sms-options-response-remove.controller.js
+++ b/packages/ovh-manager-sms/options/response/remove/telecom-sms-options-response-remove.controller.js
@@ -1,70 +1,71 @@
-angular
-  .module('managerApp')
-  .controller('TelecomSmsOptionsResponseRemoveCtrl', class TelecomSmsOptionsResponseRemoveCtrl {
-    constructor(
-      $q, $stateParams, $timeout, $uibModalInstance,
-      OvhApiSms, SmsMediator, service, index, option,
-    ) {
-      this.$q = $q;
-      this.$stateParams = $stateParams;
-      this.$timeout = $timeout;
-      this.$uibModalInstance = $uibModalInstance;
-      this.api = {
-        sms: OvhApiSms.v6(),
-      };
-      this.SmsMediator = SmsMediator;
-      this.service = service;
-      this.index = index;
-      this.option = option;
-    }
+import angular from 'angular';
+import _ from 'lodash';
 
-    $onInit() {
-      this.loading = {
-        removeTrackingOption: false,
-      };
-      this.removed = false;
-      this.model = {
-        service: angular.copy(this.service),
-        index: this.index,
-        option: this.option,
-      };
-    }
+export default class TelecomSmsOptionsResponseRemoveCtrl {
+  constructor(
+    $q, $stateParams, $timeout, $uibModalInstance,
+    OvhApiSms, SmsMediator, service, index, option,
+  ) {
+    this.$q = $q;
+    this.$stateParams = $stateParams;
+    this.$timeout = $timeout;
+    this.$uibModalInstance = $uibModalInstance;
+    this.api = {
+      sms: OvhApiSms.v6(),
+    };
+    this.SmsMediator = SmsMediator;
+    this.service = service;
+    this.index = index;
+    this.option = option;
+  }
 
-    /**
-       * Remove sms response tracking options.
-       * @return {Promise}
-       */
-    remove() {
-      this.loading.removeTrackingOption = true;
-      _.remove(
-        this.model.service.smsResponse.trackingOptions,
-        this.model.service.smsResponse.trackingOptions[this.model.index],
-      );
-      return this.$q.all([
-        this.api.sms.edit({
-          serviceName: this.$stateParams.serviceName,
-        }, {
-          smsResponse: {
-            trackingOptions: this.model.service.smsResponse.trackingOptions,
-            responseType: this.model.service.smsResponse.responseType,
-          },
-        }).$promise,
-        this.$timeout(angular.noop, 1000),
-      ]).then(() => {
-        this.loading.removeTrackingOption = false;
-        this.removed = true;
-        return this.$timeout(() => this.close(), 1000);
-      }).catch(error => this.cancel({
-        type: 'API',
-        msg: error,
-      }));
-    }
+  $onInit() {
+    this.loading = {
+      removeTrackingOption: false,
+    };
+    this.removed = false;
+    this.model = {
+      service: angular.copy(this.service),
+      index: this.index,
+      option: this.option,
+    };
+  }
 
-    cancel(message) {
-      return this.$uibModalInstance.dismiss(message);
-    }
+  /**
+   * Remove sms response tracking options.
+   * @return {Promise}
+   */
+  remove() {
+    this.loading.removeTrackingOption = true;
+    _.remove(
+      this.model.service.smsResponse.trackingOptions,
+      this.model.service.smsResponse.trackingOptions[this.model.index],
+    );
+    return this.$q.all([
+      this.api.sms.edit({
+        serviceName: this.$stateParams.serviceName,
+      }, {
+        smsResponse: {
+          trackingOptions: this.model.service.smsResponse.trackingOptions,
+          responseType: this.model.service.smsResponse.responseType,
+        },
+      }).$promise,
+      this.$timeout(angular.noop, 1000),
+    ]).then(() => {
+      this.loading.removeTrackingOption = false;
+      this.removed = true;
+      return this.$timeout(() => this.close(), 1000);
+    }).catch(error => this.cancel({
+      type: 'API',
+      msg: error,
+    }));
+  }
 
-    close() {
-      return this.$uibModalInstance.close(true);
-    }
-  });
+  cancel(message) {
+    return this.$uibModalInstance.dismiss(message);
+  }
+
+  close() {
+    return this.$uibModalInstance.close(true);
+  }
+}

--- a/packages/ovh-manager-sms/options/response/telecom-sms-options-response.controller.js
+++ b/packages/ovh-manager-sms/options/response/telecom-sms-options-response.controller.js
@@ -1,5 +1,17 @@
-angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class TelecomSmsOptionsResponseCtrl {
+import angular from 'angular';
+import _ from 'lodash';
+
+import smsOptionsResponseAddTemplate from './add/telecom-sms-options-response-add.html';
+import smsOptionsResponseAddController from './add/telecom-sms-options-response-add.controller';
+import smsOptionsResponseEditTemplate from './edit/telecom-sms-options-response-edit.html';
+import smsOptionsResponseEditController from './edit/telecom-sms-options-response-edit.controller';
+import smsOptionsResponseRemoveTemplate from './remove/telecom-sms-options-response-remove.html';
+import smsOptionsResponseRemoveController from './remove/telecom-sms-options-response-remove.controller';
+
+export default class TelecomSmsOptionsResponseCtrl {
   constructor($q, $stateParams, $translate, $uibModal, OvhApiSms, SmsMediator, Toast, ToastError) {
+    'ngInject';
+
     this.$q = $q;
     this.$stateParams = $stateParams;
     this.$translate = $translate;
@@ -55,9 +67,9 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Fetch enums.
-     * @return {Promise}
-     */
+   * Fetch enums.
+   * @return {Promise}
+   */
   fetchEnums() {
     return this.SmsMediator.getApiScheme().then((schema) => {
       const smsResponseTypeEnum = {
@@ -68,9 +80,9 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Fetch service.
-     * @return {Promise}
-     */
+   * Fetch service.
+   * @return {Promise}
+   */
   fetchService() {
     return this.api.sms.get({
       serviceName: this.$stateParams.serviceName,
@@ -78,9 +90,9 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Fetch all enabled senders.
-     * @return {Promise}
-     */
+   * Fetch all enabled senders.
+   * @return {Promise}
+   */
   fetchSenders() {
     return this.api.smsSenders.query({
       serviceName: this.$stateParams.serviceName,
@@ -91,9 +103,9 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Compute remaining characters.
-     * @return {Object}
-     */
+   * Compute remaining characters.
+   * @return {Object}
+   */
   computeRemainingChar() {
     return _.assign(this.message, this.SmsMediator.getSmsInfoText(
       this.smsResponse.text,
@@ -102,9 +114,9 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Set response action.
-     * @return {Promise}
-     */
+   * Set response action.
+   * @return {Promise}
+   */
   setResponseAction() {
     this.loading.action = true;
     return this.api.sms.edit({
@@ -128,13 +140,13 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Add tracking options.
-     */
+   * Add tracking options.
+   */
   addTrackingOptions() {
     const modal = this.$uibModal.open({
       animation: true,
-      templateUrl: 'app/telecom/sms/options/response/add/telecom-sms-options-response-add.html',
-      controller: 'TelecomSmsOptionsResponseAddCtrl',
+      template: smsOptionsResponseAddTemplate,
+      controller: smsOptionsResponseAddController,
       controllerAs: 'OptionsResponseAddCtrl',
       resolve: {
         params: () => {
@@ -157,15 +169,15 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Edit tracking options.
-     * @param  {Number} $index
-     * @param  {Object} option
-     */
+   * Edit tracking options.
+   * @param  {Number} $index
+   * @param  {Object} option
+   */
   editTrackingOptions($index, option) {
     const modal = this.$uibModal.open({
       animation: true,
-      templateUrl: 'app/telecom/sms/options/response/edit/telecom-sms-options-response-edit.html',
-      controller: 'TelecomSmsOptionsResponseEditCtrl',
+      template: smsOptionsResponseEditTemplate,
+      controller: smsOptionsResponseEditController,
       controllerAs: 'OptionsResponseEditCtrl',
       resolve: {
         service: () => this.service,
@@ -185,15 +197,15 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Remove tracking options.
-     * @param  {Number} $index
-     * @param  {Object} option
-     */
+   * Remove tracking options.
+   * @param  {Number} $index
+   * @param  {Object} option
+   */
   removeTrackingOptions($index, option) {
     const modal = this.$uibModal.open({
       animation: true,
-      templateUrl: 'app/telecom/sms/options/response/remove/telecom-sms-options-response-remove.html',
-      controller: 'TelecomSmsOptionsResponseRemoveCtrl',
+      template: smsOptionsResponseRemoveTemplate,
+      controller: smsOptionsResponseRemoveController,
       controllerAs: 'OptionsResponseRemoveCtrl',
       resolve: {
         service: () => this.service,
@@ -212,14 +224,14 @@ angular.module('managerApp').controller('TelecomSmsOptionsResponseCtrl', class T
   }
 
   /**
-     * Has changed helper.
-     * @return {Boolean}
-     */
+   * Has changed helper.
+   * @return {Boolean}
+   */
   hasChanged() {
     return !(
       this.service.smsResponse.responseType === this.smsResponse.responseType
-            && this.service.smsResponse.cgiUrl === this.smsResponse.cgiUrl
-            && this.service.smsResponse.text === this.smsResponse.text
+        && this.service.smsResponse.cgiUrl === this.smsResponse.cgiUrl
+        && this.service.smsResponse.text === this.smsResponse.text
     );
   }
-});
+}

--- a/packages/ovh-manager-sms/options/response/telecom-sms-options-response.js
+++ b/packages/ovh-manager-sms/options/response/telecom-sms-options-response.js
@@ -1,17 +1,17 @@
-angular.module('managerApp').config(($stateProvider) => {
-  $stateProvider.state('telecom.sms.options.response', {
-    url: '/response',
-    views: {
-      'smsView@telecom.sms': {
-        templateUrl: 'app/telecom/sms/options/response/telecom-sms-options-response.html',
-        controller: 'TelecomSmsOptionsResponseCtrl',
-        controllerAs: 'TelecomSmsOptionsResponseCtrl',
-      },
-    },
-    translations: [
-      'common',
-      'telecom/sms/options',
-      'telecom/sms/options/response',
-    ],
-  });
-});
+import angular from 'angular';
+import uiRouter from '@uirouter/angularjs';
+import uiBootstrap from 'angular-ui-bootstrap';
+import resource from 'angular-resource';
+import translate from 'angular-translate';
+
+import routes from './telecom-sms-options-response.routes';
+
+export default angular
+  .module('ovhManagerOptionsResponse', [
+    uiRouter,
+    uiBootstrap,
+    resource,
+    translate,
+  ])
+  .config(routes)
+  .name;

--- a/packages/ovh-manager-sms/options/response/telecom-sms-options-response.routes.js
+++ b/packages/ovh-manager-sms/options/response/telecom-sms-options-response.routes.js
@@ -1,0 +1,18 @@
+import controller from './telecom-sms-options-response.controller';
+import template from './telecom-sms-options-response.html';
+
+export default /* @ngInject */ ($stateProvider) => {
+  $stateProvider.state('sms.options.response', {
+    url: '/response',
+    views: {
+      'smsView@sms': {
+        template,
+        controller,
+        controllerAs: 'TelecomSmsOptionsResponseCtrl',
+      },
+    },
+    resolve: {
+      translations: /* @ngInject */ ($translate, asyncLoader) => import(`./translations/Messages_${$translate.use()}.xml`).then(module => asyncLoader.addTranslations(module.default).then(() => $translate.refresh()).then(() => true)),
+    },
+  });
+};

--- a/packages/ovh-manager-sms/options/telecom-sms-options.js
+++ b/packages/ovh-manager-sms/options/telecom-sms-options.js
@@ -3,9 +3,20 @@ import uiRouter from '@uirouter/angularjs';
 import resource from 'angular-resource';
 import translate from 'angular-translate';
 
+import ovhManagerOptionsManage from './manage/telecom-sms-options-manage';
+import ovhManagerOptionsRecredit from './recredit/telecom-sms-options-recredit';
+import ovhManagerOptionsResponse from './response/telecom-sms-options-response';
+
 import routes from './telecom-sms-options.routes';
 
 export default angular
-  .module('ovhManagerOptions', [uiRouter, resource, translate])
+  .module('ovhManagerOptions', [
+    uiRouter,
+    resource,
+    translate,
+    ovhManagerOptionsManage,
+    ovhManagerOptionsRecredit,
+    ovhManagerOptionsResponse,
+  ])
   .config(routes)
   .name;


### PR DESCRIPTION
Due to the `smsView` ui-view slot and missing of some page headers on subsections, we at this moment lack of `<oui-back-button>` elements.

Furthermore I suspect an error on the default layout which is a mix of h-100/flex and position-absolute.

Let me know what do you think about this work in progress:)