### PR TITLE
chore(webpack): provide jquery for angular

### DIFF
--- a/packages/ovh-manager/webpack.common.js
+++ b/packages/ovh-manager/webpack.common.js
@@ -16,6 +16,7 @@ module.exports = {
       $: 'jquery',
       jQuery: 'jquery',
       jquery: 'jquery',
+      'window.jQuery': 'jquery',
     }),
     new HtmlWebpackPlugin({
       template: './packages/ovh-manager/ovh-manager.html',


### PR DESCRIPTION
### Provide `jQuery` for angular 

Before `angular.element` used `jqLite`, now it's `jQuery`.

`angular.js` use `window.jQuery` (cf: https://github.com/angular/angular.js/blob/master/src/Angular.js#L1890 )